### PR TITLE
WinINet.mqh: Fix Error (WinINet, HttpAddRequestHeaders): #12150 on Windows Server 2012 R2

### DIFF
--- a/Include/WinINet.mqh
+++ b/Include/WinINet.mqh
@@ -147,7 +147,7 @@ int WebReq(
                         "Content-Length: %d\r\n", n);
     bLen = StringToShortArray(head + headers, buff);
     if (bLen > 0 && buff[bLen - 1] == 0) bLen--;
-    if (!HttpAddRequestHeadersW(request, buff, bLen, 0x80000000))
+    if (!HttpAddRequestHeadersW(request, buff, bLen, 0x20000000 | 0x80000000))
         return _wininetErr("HttpAddRequestHeaders", session, connection, request);
 
 //- Send the request.


### PR DESCRIPTION
## PR: Fix HttpAddRequestHeaders error #12150 on Windows Server 2012 R2

### Issue Description
When using the WinINet.mqh library on Windows Server 2012 R2, an error occurs with code #12150 (ERROR_HTTP_HEADER_NOT_FOUND) specifically at the HttpAddRequestHeaders function call. This issue doesn't appear on regular Windows installations but consistently reproduces on Windows Server 2012 R2 environments.

### Root Cause
The issue stems from the flags used when calling the HttpAddRequestHeadersW function. Currently, the code only uses the HTTP_ADDREQ_FLAG_REPLACE flag (0x80000000), which works on most Windows systems but fails on Windows Server 2012 R2.

### Solution
Added the HTTP_ADDREQ_FLAG_ADD flag (0x20000000) in combination with the existing HTTP_ADDREQ_FLAG_REPLACE flag to the HttpAddRequestHeadersW call. This change maintains compatibility with all Windows versions while fixing the specific issue on Windows Server 2012 R2.

### Changes Made
Modified line 176 in WebReq function from:
```mql5
if (!HttpAddRequestHeadersW(request, buff, bLen, 0x80000000))
```

To:
```mql5
if (!HttpAddRequestHeadersW(request, buff, bLen, 0x20000000 | 0x80000000))
```

### Testing
Tested on both Windows 10 and Windows Server 2012 R2 with successful HTTP requests made on both platforms.
